### PR TITLE
HUB-17575, HUB-18047, and HUB-17977:  Config changes requiring restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+# vim working files
+.*.swp

--- a/1-hub-setup.sql
+++ b/1-hub-setup.sql
@@ -23,6 +23,8 @@ ALTER SYSTEM SET effective_cache_size TO '256MB';
 ALTER SYSTEM SET default_statistics_target TO '100';
 ALTER SYSTEM SET constraint_exclusion TO 'partition';
 ALTER SYSTEM SET autovacuum TO 'on';
+ALTER SYSTEM SET autovacuum_max_workers TO '20';
+ALTER SYSTEM SET autovacuum_vacuum_cost_limit TO '2000';
 ALTER SYSTEM SET autovacuum_vacuum_cost_delay TO '10ms';
 ALTER SYSTEM SET max_locks_per_transaction TO '256';
 ALTER SYSTEM SET escape_string_warning TO 'off';

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV POSTGRES_USER="postgres" \
 
 RUN mkdir -p /opt/blackduck/hub/hub-database/bin 
 
-COPY hub-database.sh /hub-database.sh
+COPY hub-database.sh config-settings.pgsql /
 COPY 1-hub-setup.sql 2-hub-setup.sh docker-entrypoint-initdb.d/
 COPY --from=docker-common certificate-manager.sh /opt/blackduck/hub/hub-database/bin/certmanager.sh
 COPY docker-healthcheck.sh /usr/local/bin/docker-healthcheck.sh

--- a/config-settings.pgsql
+++ b/config-settings.pgsql
@@ -1,0 +1,20 @@
+
+-- All actions in this script must be idempotent.
+
+alter system set autovacuum_max_workers = 20 ;
+alter system set autovacuum_vacuum_cost_limit = 2000 ;
+
+\q
+
+-- After we switch to PG 10 or later, we can avoid overwriting changes users may have already made.
+select
+    exists(select 1 from pg_settings where name = 'autovacuum_max_workers' and source = 'default') as do_max_workers,
+    exists(select 1 from pg_settings where name = 'autovacuum_max_cost_limit' and source = 'default') as do_cost_limit
+\gset
+\if :do_max_workers
+    alter system set autovacuum_max_workers = 20 ;
+\endif
+\if :do_cost_limit
+    alter system set autovacuum_vacuum_cost_limit = 2000 ;
+\endif
+


### PR DESCRIPTION
Modify hub-database.sh to start postgres, apply config changes needing a DB restart, and stop postgres (HUB-18047).  While at it, change the settings needed to make autovacuum more aggressive (HUB-17977).  These changes should not be used with Black Duck versions prior to 2019.02.