### PR TITLE
Dev/bboule/hub 18319 blackduck reporter role

### DIFF
--- a/2-hub-setup.sh
+++ b/2-hub-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 set -e
 
 ###
@@ -11,7 +11,7 @@ set -e
 # users will connect to bds_hub_report as blackduck_reporter(read-only)
 psql -c 'CREATE DATABASE bds_hub_report OWNER postgres ENCODING SQL_ASCII;'
 psql -c 'CREATE USER blackduck_reporter;'
-psql -b -e -U "$POSTGRES_USER" -d bds_hub_report << EOF
+psql -U "$POSTGRES_USER" -d bds_hub_report << EOF
 GRANT SELECT, INSERT, UPDATE, TRUNCATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public TO blackduck_user;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public to blackduck_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, TRUNCATE, DELETE, REFERENCES ON TABLES TO blackduck_user;

--- a/2-hub-setup.sh
+++ b/2-hub-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 set -e
 
 ###
@@ -11,14 +11,14 @@ set -e
 # users will connect to bds_hub_report as blackduck_reporter(read-only)
 psql -c 'CREATE DATABASE bds_hub_report OWNER postgres ENCODING SQL_ASCII;'
 psql -c 'CREATE USER blackduck_reporter;'
-psql -U "$POSTGRES_USER" -d bds_hub_report << EOF
+psql -b -e -U "$POSTGRES_USER" -d bds_hub_report << EOF
 GRANT SELECT, INSERT, UPDATE, TRUNCATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public TO blackduck_user;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public to blackduck_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, TRUNCATE, DELETE, REFERENCES ON TABLES TO blackduck_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO blackduck_user;
 
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO blackduck_reporter;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO blackduck_reporter;
+ALTER DEFAULT PRIVILEGES FOR ROLE blackduck IN SCHEMA public GRANT SELECT ON TABLES TO blackduck_reporter;
 EOF
 
 # Add Replication User


### PR DESCRIPTION
This fixes an issue with the default privileges.  The existing statement was setting the default privileges for tables created by the postgres user accidentally because the "FOR ROLE" clause was missing.  Postgres defaults to the current user if "FOR ROLE" is omitted.   This was causing the blackduck_reporter's read access to not be present because all the tables in the schema are created after this script runs.  The "GRANT SELECT" is a no-op here because no schema objects exist yet.